### PR TITLE
totalRequiredCores is halved with HT enabled

### DIFF
--- a/js/ost.js
+++ b/js/ost.js
@@ -58,10 +58,11 @@ function calculateAndShow() {
     var totalRequiredCores = numberOfNodes * hostCores;
     var totalVcpus = totalRequiredCores;
     if($('#check_ht').is(':checked')){
-        totalVcpus = totalRequiredCores / 2;
+        totalRequiredCores = totalRequiredCores / 2;
         console.log("======> HT enabled.");
     }
-    var subs = totalVcpus / 2;
+
+    var subs = totalRequiredCores / 2;
 
     $('#tbl_title').html('Cluster: ' + clusterName);
     $('#appInstances').html(apps);


### PR DESCRIPTION
## Description
The number of total required physical cores is the half of the total of vcpus when hyperthreading is enabled.

## Resolution
By halving `totalRequiredCores` if `check_ht` is checked the correct number of physical cores is printed without compromising the correct number of `totalVcpus`.